### PR TITLE
Add MicroBadger badge

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,7 +1,7 @@
 # apt-mirror
 
 [![Docker Stars](https://img.shields.io/docker/stars/gmitre/apt-mirror.svg)](https://hub.docker.com/r/gmitre/apt-mirror/)
-[![Docker Pulls](https://img.shields.io/docker/pulls/gmitre/apt-mirror.svg)](https://hub.docker.com/r/gmitre/apt-mirror/)
+[![Docker Pulls](https://img.shields.io/docker/pulls/gmitre/apt-mirror.svg)](https://hub.docker.com/r/gmitre/apt-mirror/) [![](https://images.microbadger.com/badges/image/gmitre/apt-mirror.svg)](https://microbadger.com/images/gmitre/apt-mirror "Get your own image badge on microbadger.com")
 
 ## How to run ?
 
@@ -18,4 +18,4 @@ $ docker run -p 80:80 -v /data/mirror:/var/spool/apt-mirror gmitre/apt-mirror
 
 ## Available mount points
 `/var/spool/apt-mirror`
-`/etc/apt/mirror.list`
+`/etc/apt/mirror.list` 


### PR DESCRIPTION
We saw your image on Docker Hub at [gmitre/apt-mirror](https://hub.docker.com/r/gmitre/apt-mirror/), and we thought you might like this badge for your GitHub readme showing the image contents.

The badge shows the number of layers and download size of your Docker image, and links to our site where you can see the [contents of each layer](https://microbadger.com/images/gmitre/apt-mirror).

As you're using an automated build it will also show up in your Docker Hub description.

[![](https://images.microbadger.com/badges/image/gmitre/apt-mirror.svg)](https://microbadger.com/images/gmitre/apt-mirror)
